### PR TITLE
Update readme for installing diesel

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ export WHO_AM_I=localhost:8000
 export API_KEY=secret
 ```
 4. Install diesel
-```cargo install diesel@1.4.1 --no-default-features --features postgres```
+```cargo install diesel_cli@1.4.1 --no-default-features --features postgres```
 5. Setup the DBs
 ```
 diesel setup

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ export WHO_AM_I=localhost:8000
 export API_KEY=secret
 ```
 4. Install diesel
-```cargo install disel@1.4.1 --no-features --features postgres```
+```cargo install diesel@1.4.1 --no-default-features --features postgres```
 5. Setup the DBs
 ```
 diesel setup


### PR DESCRIPTION
The readme misspelled the word diesel and I assume the `--no-features` should actually be `--no-default-features`.